### PR TITLE
ADCM-2420 FIX: return install_reqs_to_default.sh

### DIFF
--- a/test/install_reqs_to_default.sh
+++ b/test/install_reqs_to_default.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+source /adcm/venv/default/bin/activate
+pip install -r /requirements-test.txt


### PR DESCRIPTION
This is a fix for stupid bug with missing install_reqs_to_default.sh
file.
This file is in base image already, so we have an issue with code
is not equal to real base image.

This mistake is around manual build by @acmnu.
Hope it is the only trouble.